### PR TITLE
Background classification

### DIFF
--- a/Actions/SteppingAction.cpp
+++ b/Actions/SteppingAction.cpp
@@ -63,6 +63,9 @@ void SteppingAction::UserSteppingAction(const G4Step* aStep)
   PrimaryParticleInformation* info  = static_cast<PrimaryParticleInformation*> (aStep->GetTrack()->GetDynamicParticle()->GetPrimaryParticle()->GetUserInformation());
   if (info != 0 ) {
     //! particle quanta interact in phantom or frame (but not SD!)
-    info->SetGammaMultiplicity(PrimaryParticleInformation::kBackground);
+    double momentumChange = abs(aStep->GetPostStepPoint()->GetMomentum().mag2()-aStep->GetPreStepPoint()->GetMomentum().mag2()); 
+    if ( momentumChange > EventMessenger::GetEventMessenger()->GetAllowedMomentumTransfer() ) {
+      info->SetGammaMultiplicity(PrimaryParticleInformation::kBackground);
+    }
   }
 }

--- a/Core/DetectorSD.cpp
+++ b/Core/DetectorSD.cpp
@@ -19,6 +19,7 @@
 #include "DetectorSD.h"
 #include <algorithm>
 #include <G4SystemOfUnits.hh>
+#include "../Info/EventMessenger.h"
 
 DetectorSD::DetectorSD(G4String name, G4int scinSum, G4double timeMergeValue) :
   G4VSensitiveDetector(name), totScinNum(scinSum), timeIntervals(timeMergeValue)
@@ -46,7 +47,8 @@ G4bool DetectorSD::ProcessHits(G4Step* aStep, G4TouchableHistory*)
 {
   G4double edep = aStep->GetTotalEnergyDeposit();
   if (edep == 0.0) {
-    if ( (aStep->GetPostStepPoint()->GetMomentum().mag2()-aStep->GetPreStepPoint()->GetMomentum().mag2()) > 0 ) {
+    double momentumChange = abs(aStep->GetPostStepPoint()->GetMomentum().mag2()-aStep->GetPreStepPoint()->GetMomentum().mag2()); 
+    if ( momentumChange > EventMessenger::GetEventMessenger()->GetAllowedMomentumTransfer()  ) {
       // particle quanta interact in detector but does not deposit energy
       // (vide Rayleigh scattering)
       if (aStep->GetTrack()->GetParentID() == 0) {

--- a/Info/EventMessenger.cpp
+++ b/Info/EventMessenger.cpp
@@ -63,6 +63,11 @@ EventMessenger::EventMessenger()
   fSaveSeed = new G4UIcmdWithABool("/jpetmc/SaveSeed", this);
   fSaveSeed->SetGuidance("Save random seed (default false).");
 
+  fCMDAllowedMomentumTransfer = new G4UIcmdWithADoubleAndUnit("/jpetmc/setAllowedMomentumTransfer",this);
+  fCMDAllowedMomentumTransfer->SetGuidance("Limit on momentum transfer that will classify interaction as background (10keV)");
+  fCMDAllowedMomentumTransfer->SetDefaultValue(1*keV); 
+  fCMDAllowedMomentumTransfer->SetUnitCandidates("keV");
+
 }
 
 EventMessenger::~EventMessenger()
@@ -124,5 +129,9 @@ void EventMessenger::SetNewValue(G4UIcommand* command, G4String newValue)
 
   if (command == fAddDatetime) {
     fOutputWithDatetime = fAddDatetime->GetNewBoolValue(newValue);
+  }
+
+  if (command == fCMDAllowedMomentumTransfer) {
+    fAllowedMomentumTransfer = fCMDAllowedMomentumTransfer->GetNewDoubleValue(newValue); 
   }
 }

--- a/Info/EventMessenger.h
+++ b/Info/EventMessenger.h
@@ -75,6 +75,11 @@ public:
     return fExcludedMultiplicity;
   }
 
+  G4double GetAllowedMomentumTransfer()
+  {
+    return fAllowedMomentumTransfer;
+  }
+
 
   bool SetRandomSeed()
   {
@@ -103,6 +108,7 @@ private:
   G4UIcmdWithAnInteger* fCMDExcludedMulti;
   G4UIcmdWithABool* fRandomSeed;
   G4UIcmdWithABool* fSaveSeed;
+  G4UIcmdWithADoubleAndUnit* fCMDAllowedMomentumTransfer; 
   bool fPrintStatistics = false;
   G4int fPrintPower = 10;
   bool fShowProgress = false;
@@ -113,6 +119,7 @@ private:
   G4int fExcludedMultiplicity = 1;
   bool fSetRandomSeed = true;
   bool fSaveRandomSeed = false;
+  G4double fAllowedMomentumTransfer = 1*keV;
 
 };
 


### PR DESCRIPTION
Events are classified as background if momentum transfer is greater than 1keV (this value can be changed through messenger). Fixed problem with low momentum transfer that occurs in air. Careful in analysis - those events will not be entangled anymore!