### PR TITLE
Fix problems with seeding random number generator

### DIFF
--- a/Actions/RunAction.cpp
+++ b/Actions/RunAction.cpp
@@ -29,6 +29,8 @@ void RunAction::BeginOfRunAction(const G4Run*)
 {
   fHistoManager->Book();
 
+  int mask = 01001010;
+
   if(fEvtMessenger->GetSeed() == 0){
     /**
      *
@@ -44,11 +46,11 @@ void RunAction::BeginOfRunAction(const G4Run*)
     system_clock::time_point now = system_clock::now();
     long seed = (UInt_t)(system_clock::to_time_t ( now )) * 677*::getpid();
     G4Random::setTheSeed(seed);
-    gRandom->SetSeed(seed);
+    gRandom->SetSeed(seed^mask);
   }
   else{
     gRandom->SetSeed(fEvtMessenger->GetSeed());
-    G4Random::setTheSeed(fEvtMessenger->GetSeed());
+    G4Random::setTheSeed(fEvtMessenger->GetSeed()^mask);
   }
 }
 

--- a/Actions/RunAction.cpp
+++ b/Actions/RunAction.cpp
@@ -19,6 +19,7 @@
 #include <G4Run.hh>
 #include <Randomize.hh>
 #include <TRandom3.h>
+#include <chrono>
 
 RunAction::RunAction(HistoManager* histo) : G4UserRunAction(),  fHistoManager(histo) {}
 

--- a/Actions/RunAction.h
+++ b/Actions/RunAction.h
@@ -36,6 +36,7 @@ public:
 
 private:
   HistoManager* fHistoManager;
+  EventMessenger* fEvtMessenger = EventMessenger::GetEventMessenger();
 
 };
 

--- a/Info/EventMessenger.cpp
+++ b/Info/EventMessenger.cpp
@@ -33,7 +33,7 @@ EventMessenger::EventMessenger()
   fDirectory->SetGuidance("Define events to save");
 
   fCMDKillEventsEscapingWorld = new G4UIcmdWithABool("/jpetmc/event/saveEvtsDetAcc",this);
-  fCMDKillEventsEscapingWorld->SetGuidance("Killing events when generated particle escapes detector"); 
+  fCMDKillEventsEscapingWorld->SetGuidance("Killing events when generated particle escapes detector");
 
   fPrintStat = new G4UIcmdWithABool("/jpetmc/event/printEvtStat", this);
   fPrintStat->SetGuidance("Print how many events was generated");
@@ -57,15 +57,16 @@ EventMessenger::EventMessenger()
   fAddDatetime = new G4UIcmdWithABool("/jpetmc/output/AddDatetime", this);
   fAddDatetime->SetGuidance("Adds to the output file name date and time of simulation start.");
 
-  fRandomSeed = new G4UIcmdWithABool("/jpetmc/SetRandomSeed", this);
-  fRandomSeed->SetGuidance("Use random seed (default true).");
+  fSetSeed = new G4UIcmdWithAnInteger("/jpetmc/SetSeed", this);
+  fSetSeed->SetGuidance("Use specific seed. If 0 provided seed will be random.");
+  fSetSeed->SetDefaultValue(0);
 
   fSaveSeed = new G4UIcmdWithABool("/jpetmc/SaveSeed", this);
   fSaveSeed->SetGuidance("Save random seed (default false).");
 
   fCMDAllowedMomentumTransfer = new G4UIcmdWithADoubleAndUnit("/jpetmc/setAllowedMomentumTransfer",this);
   fCMDAllowedMomentumTransfer->SetGuidance("Limit on momentum transfer that will classify interaction as background (10keV)");
-  fCMDAllowedMomentumTransfer->SetDefaultValue(1*keV); 
+  fCMDAllowedMomentumTransfer->SetDefaultValue(1*keV);
   fCMDAllowedMomentumTransfer->SetUnitCandidates("keV");
 
 }
@@ -76,7 +77,7 @@ EventMessenger::~EventMessenger()
   delete fPrintStatPower;
   delete fPrintStatBar;
   delete fAddDatetime;
-  delete fRandomSeed;
+  delete fSetSeed;
   delete fSaveSeed;
   delete fCMDKillEventsEscapingWorld;
   delete fCMDMinRegMulti;
@@ -111,7 +112,7 @@ void EventMessenger::SetNewValue(G4UIcommand* command, G4String newValue)
     fOutputWithDatetime = fAddDatetime->GetNewBoolValue(newValue);
   }
 
-  if (command == fCMDKillEventsEscapingWorld) { 
+  if (command == fCMDKillEventsEscapingWorld) {
     fKillEventsEscapingWorld = fCMDKillEventsEscapingWorld->GetNewBoolValue(newValue);
   }
 
@@ -119,8 +120,8 @@ void EventMessenger::SetNewValue(G4UIcommand* command, G4String newValue)
     fExcludedMultiplicity = fCMDExcludedMulti->GetNewIntValue(newValue);
   }
 
-  if (command == fRandomSeed) {
-    fSetRandomSeed = fRandomSeed->GetNewBoolValue(newValue);
+  if (command == fSetSeed) {
+    fSeed = fSetSeed->GetNewIntValue(newValue);
   }
 
   if (command == fSaveSeed) {
@@ -132,6 +133,6 @@ void EventMessenger::SetNewValue(G4UIcommand* command, G4String newValue)
   }
 
   if (command == fCMDAllowedMomentumTransfer) {
-    fAllowedMomentumTransfer = fCMDAllowedMomentumTransfer->GetNewDoubleValue(newValue); 
+    fAllowedMomentumTransfer = fCMDAllowedMomentumTransfer->GetNewDoubleValue(newValue);
   }
 }

--- a/Info/EventMessenger.h
+++ b/Info/EventMessenger.h
@@ -81,9 +81,9 @@ public:
   }
 
 
-  bool SetRandomSeed()
+  G4int GetSeed()
   {
-    return fSetRandomSeed;
+    return fSeed;
   }
 
   bool SaveSeed()
@@ -106,9 +106,9 @@ private:
   G4UIcmdWithAnInteger* fCMDMinRegMulti;
   G4UIcmdWithAnInteger* fCMDMaxRegMulti;
   G4UIcmdWithAnInteger* fCMDExcludedMulti;
-  G4UIcmdWithABool* fRandomSeed;
+  G4UIcmdWithAnInteger* fSetSeed;
   G4UIcmdWithABool* fSaveSeed;
-  G4UIcmdWithADoubleAndUnit* fCMDAllowedMomentumTransfer; 
+  G4UIcmdWithADoubleAndUnit* fCMDAllowedMomentumTransfer;
   bool fPrintStatistics = false;
   G4int fPrintPower = 10;
   bool fShowProgress = false;
@@ -117,7 +117,7 @@ private:
   G4int fMinRegisteredMultiplicity = 0;
   G4int fMaxRegisteredMultiplicity = 10;
   G4int fExcludedMultiplicity = 1;
-  bool fSetRandomSeed = true;
+  G4int fSeed = 0;
   bool fSaveRandomSeed = false;
   G4double fAllowedMomentumTransfer = 1*keV;
 

--- a/JPetMC.cpp
+++ b/JPetMC.cpp
@@ -22,31 +22,33 @@
 #include <G4INCLRandom.hh>
 #include <G4UImanager.hh>
 #include "Info/EventMessenger.h"
-#include <fstream> 
+#include <fstream>
 #include <random>
+#include <TRandom3.h>
 
 void setRandomSeed()
 {
-  long seeds[2];
-  
+  long seed;
+
   std::uniform_int_distribution<long> d(0, LONG_MAX);
   std::random_device rd1;
 
-  seeds[0] = d(rd1);
-  seeds[1] = d(rd1);
-  G4Random::setTheSeeds(seeds);
+  seed = d(rd1);
 
-  if (EventMessenger::GetEventMessenger()->SaveSeed()) {
-    std::ofstream file;
-    file.open ("seed", std::ofstream::out | std::ofstream::app);
-    file << seeds[0] << "\n" << seeds[1] << "\n";
-    file.close();
-  }
+  G4Random::setTheEngine(new CLHEP::MTwistEngine());
+  G4Random::setTheSeed(seed);
+
 }
 
 
 int main (int argc, char** argv)
 {
+  delete gRandom;
+  gRandom = new TRandom3(0);
+
+  std::cout << gRandom ->GetSeed() << std::endl;
+
+  // setRandomSeed();
 
   G4UIExecutive* ui = 0;
   if (argc == 1) {
@@ -74,13 +76,21 @@ int main (int argc, char** argv)
     delete ui;
   }
 
-  if (EventMessenger::GetEventMessenger()->SetRandomSeed()) {
-    setRandomSeed();
-  }
-
 
   delete visManager;
   delete runManager;
+
+  if (EventMessenger::GetEventMessenger()->SaveSeed()) {
+    long seed = G4Random::getTheSeed();
+    std::ofstream file;
+    file.open ("seed", std::ofstream::out | std::ofstream::app);
+    file << seed << "\n";
+    file.close();
+  }
+
+
+  // G4Random::showEngineStatus();
+  std::cout << gRandom ->GetSeed() << std::endl;
   return 0;
 }
 

--- a/JPetMC.cpp
+++ b/JPetMC.cpp
@@ -24,31 +24,13 @@
 #include "Info/EventMessenger.h"
 #include <fstream>
 #include <random>
-#include <TRandom3.h>
 
-void setRandomSeed()
-{
-  long seed;
-
-  std::uniform_int_distribution<long> d(0, LONG_MAX);
-  std::random_device rd1;
-
-  seed = d(rd1);
-
-  G4Random::setTheEngine(new CLHEP::MTwistEngine());
-  G4Random::setTheSeed(seed);
-
-}
 
 
 int main (int argc, char** argv)
 {
-  delete gRandom;
-  gRandom = new TRandom3(0);
 
-  std::cout << gRandom ->GetSeed() << std::endl;
-
-  setRandomSeed();
+  G4Random::setTheEngine(new CLHEP::MTwistEngine());
 
   G4UIExecutive* ui = 0;
   if (argc == 1) {
@@ -88,8 +70,6 @@ int main (int argc, char** argv)
     file.close();
   }
 
-
-  // G4Random::showEngineStatus();
 
   return 0;
 }

--- a/JPetMC.cpp
+++ b/JPetMC.cpp
@@ -48,7 +48,7 @@ int main (int argc, char** argv)
 
   std::cout << gRandom ->GetSeed() << std::endl;
 
-  // setRandomSeed();
+  setRandomSeed();
 
   G4UIExecutive* ui = 0;
   if (argc == 1) {
@@ -90,7 +90,7 @@ int main (int argc, char** argv)
 
 
   // G4Random::showEngineStatus();
-  std::cout << gRandom ->GetSeed() << std::endl;
+
   return 0;
 }
 


### PR DESCRIPTION
There were two problems with random number generation:
1) Previous implementation was designed to allow user to set random seed. Unfortunately we were setting that seed after simulation which resulted in using default constructor of random engine. It was JamesRandom engine and it was always seeded to the first number from seed table (SeedTable.h) - 9876. I changed default engine to Mersenne Twister and seeding it with random value which can be stored in a file (user can specify, by default false). It is still possible to repeat simulation by changing source code to the desired seed.
2) In PrimaryGenerator we are using TGenPhaseSpace which in method Generate() is using gRandom generator. It is set to TRandom3 with seed 4357 which means that every run of simulation we hat the same sequence of events. To fix it I reinitialized gRandom variable with 0 - therefore allowing ROOT to calculate unique seed based on time and process PID. We have the same problem with gRandom in Framework