### PR TITLE
Update & simplify Jenkins tests

### DIFF
--- a/jenkins/root_6/Dockerfile
+++ b/jenkins/root_6/Dockerfile
@@ -1,74 +1,24 @@
 FROM ubuntu:xenial
 LABEL MAINTAINER Kamil Rakoczy <kamil.rakoczy@student.uj.edu.pl>
-RUN apt-get update \
-  && apt-get -y install \
-  ccache \
-  cmake \
-  g++ \
-  gcc \
-  gfortran \
-  git \
-  libgif-dev \
-  libgsl0-dev \
-  libjpeg-dev \
-  libpq-dev \
-  libpythia8-dev \
-  libtbb-dev \
-  libtiff-dev \
-  libx11-dev \
-  libxext-dev \
-  libxft-dev \
-  libxml2-dev \
-  libxpm-dev \
-  locales \
-  lsb-release \
-  make \
-  python \
-  python-dev \
-  sudo \
-  doxygen \
-  libfftw3-3 \
-  libfftw3-dev \
-  file \
-  wget \
-  apt-transport-https \
-  man-db \
-  mesa-utils \
-  unzip \
-  freeglut3-dev \
-  graphviz \
-  && localedef -i en_US -f UTF-8 en_US.UTF-8
+
+RUN apt-get update && apt-get -y install git libboost-all-dev libtbb-dev cmake libfftw3-3 libfftw3-dev sshpass wget g++
+>>>>>>> 546451b... Update & simplify Jenkins tests
 
 RUN rm -rf /var/lib/apt/lists/*
-RUN mkdir -p /framework-dependencies
-RUN mkdir -p /framework-dependencies/lib
-RUN mkdir -p /framework-dependencies/include
-RUN wget https://sourceforge.net/projects/boost/files/boost/1.58.0/boost_1_58_0.tar.gz -P /framework-dependencies
-RUN tar xvxf /framework-dependencies/boost_1_58_0.tar.gz
-RUN cd /boost_1_58_0 && ./bootstrap.sh 
-RUN cd /boost_1_58_0 && ./b2 install --prefix=/framework-dependencies --with-regex --with-test --with-program_options --with-filesystem --with-log
-
-RUN wget https://root.cern.ch/download/root_v6.08.06.source.tar.gz
-RUN tar xvzf root_v6.08.06.source.tar.gz
-RUN mkdir -p root-system
-RUN mkdir -p root-system/etc
-RUN cd root-6.08.06/build && cmake -Dbuiltin_fftw3=ON -Dbuiltin_ftgl=ON -Dfail-on-missing=ON -Dgviz=OFF -Dbonjour=OFF -Dkrb5=OFF -Dcastor=OFF -Drfio=OFF -Dmysql=OFF -Doracle=OFF -Dodbc=OFF -Dsqlite=OFF -Dpythia6=OFF -Dbuiltin_xrootd=ON -Dgfal=OFF -Ddcache=OFF -Dldap=OFF -Dchirp=OFF -Dhdfs=OFF -Dbuiltin_davix=ON -DCMAKE_INSTALL_PREFIX=/root-system --build .. && make && make install
-
-RUN mkdir -p /clhep
-RUN mkdir clhep-install
-RUN wget http://proj-clhep.web.cern.ch/proj-clhep/DISTRIBUTION/tarFiles/clhep-2.4.1.0.tgz -P clhep
-WORKDIR /clhep
-RUN tar xvxf clhep-2.4.1.0.tgz
-RUN mkdir -p 2.4.1.0/CLHEP/build && cd 2.4.1.0/CLHEP/build && cmake -DCMAKE_INSTALL_PREFIX=/clhep-install .. && make && make test && make install
 
 WORKDIR /
+
+RUN wget https://root.cern/download/root_v6.12.06.Linux-ubuntu16-x86_64-gcc5.4.tar.gz
+RUN tar xzf root_v6.12.06.Linux-ubuntu16-x86_64-gcc5.4.tar.gz
+RUN rm /root_v6.12.06.Linux-ubuntu16-x86_64-gcc5.4.tar.gz
+
 RUN mkdir -p geant4
 RUN mkdir -p geant4-install
 RUN wget https://github.com/Geant4/geant4/archive/v10.4.2.tar.gz -P geant4
 
 WORKDIR /geant4
 RUN tar xvxf v10.4.2.tar.gz
-RUN mkdir -p geant4-10.4.2/build && cd geant4-10.4.2/build && export CLHEP_DIR=/clhep-install && cmake -DCMAKE_INSTALL_PREFIX=/geant4-install -DGEANT4_USE_SYSTEM_CLHEP=ON .. && make && make install
+RUN mkdir -p geant4-10.4.2/build && cd geant4-10.4.2/build && cmake -DCMAKE_INSTALL_PREFIX=/geant4-install .. && make && make install
 
 WORKDIR /
 RUN mkdir -p /CADMesh-install
@@ -76,6 +26,5 @@ RUN /bin/bash -c "source /geant4-install/bin/geant4.sh" && git clone https://git
 
 WORKDIR /J-PET-geant4
 COPY docker-entrypoint.sh /usr/local/bin/
-RUN chmod 777 /usr/local/bin/docker-entrypoint.sh \
-  && ln -s /usr/local/bin/docker-entrypoint.sh / && ln -s /usr/local/bin/docker-entrypoint.sh /J-PET-geant4
+RUN chmod 777 /usr/local/bin/docker-entrypoint.sh && ln -s /usr/local/bin/docker-entrypoint.sh / && ln -s /usr/local/bin/docker-entrypoint.sh /J-PET-geant4
 ENTRYPOINT [ "bash", "-c", "docker-entrypoint.sh" ]

--- a/jenkins/root_6/Dockerfile
+++ b/jenkins/root_6/Dockerfile
@@ -1,9 +1,7 @@
 FROM ubuntu:xenial
-LABEL MAINTAINER Kamil Rakoczy <kamil.rakoczy@student.uj.edu.pl>
+LABEL MAINTAINER Aleksander Gajos <aleksander.gajos@uj.edu.pl>
 
 RUN apt-get update && apt-get -y install git libboost-all-dev libtbb-dev cmake libfftw3-3 libfftw3-dev sshpass wget g++
->>>>>>> 546451b... Update & simplify Jenkins tests
-
 RUN rm -rf /var/lib/apt/lists/*
 
 WORKDIR /

--- a/jenkins/root_6/docker-entrypoint.sh
+++ b/jenkins/root_6/docker-entrypoint.sh
@@ -6,19 +6,11 @@ function executeCommand {
     echo "Exit code[" $@ "]: $rc"
 }
 
+executeCommand "source /geant4-install/bin/geant4.sh"
+executeCommand "source /root/bin/thisroot.sh"
+executeCommand "export cadmesh_DIR=/CADMesh-install"
 executeCommand "mkdir -p build"
 executeCommand "cd build"
-executeCommand "export CMAKE_LIBRARY_PATH=$CMAKE_LIBRARY_PATH:/framework-dependencies/lib"
-executeCommand "export CMAKE_INCLUDE_PATH=$CMAKE_INCLUDE_PATH:/framework-dependencies/include"
-executeCommand "export CLHEP_DIR=/clhep-install"
-executeCommand "export CLHEP_INCLUDE_DIR=/clhep-install/include"
-executeCommand "export CLHEP_LIBRARY=/clhep-install/lib"
-executeCommand "export LD_LIBRARY_PATH=${CLHEP_LIBRARY}:${LD_LIBRARY_PATH}"
-executeCommand "export PATH=/clhep-install/bin:$PATH"
-executeCommand "source /geant4-install/bin/geant4.sh"
-executeCommand "source /root-system/bin/thisroot.sh"
-executeCommand "export LD_LIBRARY_PATH=/CADMesh-install/lib:${LD_LIBRARY_PATH}"
-executeCommand "export cadmesh_DIR=/CADMesh-install"
 executeCommand "cmake .."
 executeCommand "make"
 


### PR DESCRIPTION
The Jenkins tests' configuration contained a lot of now-obsolete steps such as manually building and using a specific Boost version and building ROOT from source while the binary builds from root.cern.ch are known to work fine on Ubutntu 16.04.

I have simplified the configuration so as to:
- use Boost from Ubuntu 16.04 repositories
- download and use a binary build of ROOT (will significantly speed up the test builds)
- not build a standalone version of CLHEP for Geant4 (I do not know why this was needed before but using Geant4's built-in CLHEP does not seem to break anything)

As the Jenkins tests for this PR have passed successfully, I suggest to merge this PR before PR #44, then rebase #44 on top of these changes and see if the test build for #44 is fixed then. Even if this was not the core of the problem in case of #44, this cleanup of Jenkins config should facilitate further testing.