### PR TITLE
Correcting json printout to include frame/setup

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -100,7 +100,7 @@ include_directories(SYSTEM ${CADMESH_INCLUDE_DIRS})
 set(Boost_USE_STATIC_LIBS OFF)
 set(Boost_USE_MULTITHREADED ON)
 set(Boost_USE_STATIC_RUNTIME OFF)
-find_package(Boost 1.50 REQUIRED 
+find_package(Boost 1.50 REQUIRED
              COMPONENTS filesystem
                         program_options
                         regex

--- a/Core/DetectorConstruction.cpp
+++ b/Core/DetectorConstruction.cpp
@@ -45,8 +45,8 @@ DetectorConstruction* DetectorConstruction::GetInstance()
 }
 
 DetectorConstruction::DetectorConstruction() :
-G4VUserDetectorConstruction(), fRunNumber(0), fLoadScintillators(false), 
-fLoadCADFrame(false), fLoadWrapping(true), fLoadModularLayer(false), fCreateGeometryFile(false)
+G4VUserDetectorConstruction(), fRunNumber(0), fLoadScintillators(false),
+fLoadCADFrame(false), fLoadWrapping(true), fLoadModularLayer(false)
 {
   InitializeMaterials();
   fMessenger = new DetectorConstructionMessenger(this);
@@ -91,7 +91,7 @@ G4VPhysicalVolume* DetectorConstruction::Construct()
   } else if (fRunNumber == 7) {
     ConstructTargetRun7();
   }
-  
+
   if (fCreateGeometryFile) {
     CreateGeometryFile();
   }
@@ -325,15 +325,17 @@ void DetectorConstruction::ConstructScintillators()
 
       G4Transform3D transform(rot, loc);
       G4String name = "scin_" + G4UIcommand::ConvertToString(icopy);
-      
+
       if (fCreateGeometryFile) {
-        Scin scinTemp(moduleNumber, moduleNumber, DetectorConstants::scinDim[0], DetectorConstants::scinDim[1], DetectorConstants::scinDim[2],
-                        DetectorConstants::radius[j]*cos((phi+fi)*180/M_PI)/10, DetectorConstants::radius[j]*sin((phi+fi)*180/M_PI)/10, 0);
+        Scin scinTemp(
+          moduleNumber, moduleNumber, DetectorConstants::scinDim[0], DetectorConstants::scinDim[1], DetectorConstants::scinDim[2],
+          DetectorConstants::radius[j]*cos((phi+fi)*180/M_PI)/10, DetectorConstants::radius[j]*sin((phi+fi)*180/M_PI)/10, 0
+        );
         fScinContainer.push_back(scinTemp);
         Slot slotTemp(moduleNumber, fLayerNumber, (phi+fi)*180/M_PI, "single");
         fSlotContainer.push_back(slotTemp);
       }
-    
+
       new G4PVPlacement(
         transform, fScinLog, name, fWorldLogical, true, icopy, checkOverlaps
       );
@@ -442,16 +444,16 @@ void DetectorConstruction::ConstructScintillatorsModularLayer()
   }
 }
 
-void DetectorConstruction::ConstructLayers(std::vector<G4double>& radius_dynamic, G4int& numberofModules, 
+void DetectorConstruction::ConstructLayers(std::vector<G4double>& radius_dynamic, G4int& numberofModules,
                                            G4double& angDisp_dynamic, G4int& icopyI)
 {
   G4double phi = 0.0;
   G4double phi1 = 0.0;
   fLayerNumber++;
-  
+
   Layer layTemp(fLayerNumber, "Layer nr " + std::to_string(fLayerNumber), radius_dynamic[6], 1);
   fLayerContainer.push_back(layTemp);
-  
+
   G4int moduleNumber = 0;
   for (int i = 0; i < numberofModules; i++){
     phi = (i * 2 * M_PI / numberofModules);
@@ -464,15 +466,17 @@ void DetectorConstruction::ConstructLayers(std::vector<G4double>& radius_dynamic
       G4Transform3D transform(rot, loc);
       moduleNumber = icopyI + i * 13 + j + 6;
       G4String nameNewI = "scin_" + G4UIcommand::ConvertToString(moduleNumber);
-      
+
       if (fCreateGeometryFile) {
-        Scin scinTemp(moduleNumber, moduleNumber, DetectorConstants::scinDim_inModule[0], DetectorConstants::scinDim_inModule[1], 
-                      DetectorConstants::scinDim_inModule[2], (radius_new/cm)*cos(phi1*180/M_PI), (radius_new/cm)*sin(phi1*180/M_PI), 0);
+        Scin scinTemp(
+          moduleNumber, moduleNumber, DetectorConstants::scinDim_inModule[0], DetectorConstants::scinDim_inModule[1],
+          DetectorConstants::scinDim_inModule[2], (radius_new/cm)*cos(phi1*180/M_PI), (radius_new/cm)*sin(phi1*180/M_PI), 0
+        );
         fScinContainer.push_back(scinTemp);
         Slot slotTemp(moduleNumber, fLayerNumber, phi*180/M_PI, "module");
         fSlotContainer.push_back(slotTemp);
       }
-      
+
       new G4PVPlacement(
         transform, fScinLogInModule, nameNewI, fWorldLogical,
         true, icopyI + i * 13 + j + 6, checkOverlaps
@@ -877,137 +881,178 @@ void DetectorConstruction::ConstructTargetRun7()
 
 void DetectorConstruction::CreateGeometryFile()
 {
-  std::ofstream fileWithGeometry;
-  std::string fileName = "newGeometry.json";
-  fileWithGeometry.open(fileName, std::ios::out);
-  G4cout << "--- Saving simulated geometry to " << fileName << " ---" << G4endl;
-  if (fileWithGeometry.is_open()) {
-    int runNumber = fRunNumber+90;
-    if (fCreateOldGeometryFileStyle) {
-      G4cout << "--- Creating old style of the geometry file ---" << G4endl;
-      boost::property_tree::ptree jsonFile, full, partial, element;
-      std::string runNumberStr = std::to_string(runNumber) + std::string(".");
+  namespace pt = boost::property_tree;
+  using namespace std;
 
-      for (unsigned i=0; i<fScinContainer.size(); i++) {
-        element.clear();
-        element.put("id", "*" + std::to_string(fScinContainer[i].fId) + "*");
-        element.put("barrelSlots_id", "*" + std::to_string(fScinContainer[i].fId) + "*");
-        std::stringstream stream, stream2, stream3;
-        stream << std::fixed << std::setprecision(0) << fScinContainer[i].fHeight;
-        element.put("height", "*" + stream.str() + "*");
-        stream2 << std::fixed << std::setprecision(0) << fScinContainer[i].fWidth;
-        element.put("width", "*" + stream2.str() + "*");
-        stream3 << std::fixed << std::setprecision(0) << fScinContainer[i].fLength;
-        element.put("length", "*" + stream3.str() + "*");
-        element.put("attenuation_length", "*" + std::to_string(0) + "*");
-        partial.push_back(std::make_pair("", element));
-      }
-      full.add_child("scintillators", partial);
-      
-      partial.clear();
-      for (unsigned i=0; i<fSlotContainer.size(); i++) {
-        element.clear();
-        element.put("id", "*" + std::to_string(fSlotContainer[i].fId) + "*");
-        element.put("frame_id", "*" + std::to_string(1) + "*");
-        element.put("name", std::to_string(1));
-        element.put("layers_id", std::to_string(1));
-        std::stringstream stream;
-        stream << std::fixed << std::setprecision(3) << fSlotContainer[i].fTheta;
-        element.put("theta1", "*" + stream.str() + "*");
-        element.put("active", "true");
-        partial.push_back(std::make_pair("", element));
-      }
-      full.add_child("barrelSlots", partial);
-  
-      partial.clear();
-      for (unsigned i=0; i<fLayerContainer.size(); i++) {
-        element.clear();
-        element.put("id", "*" + std::to_string(fLayerContainer[i].fId) + "*");
-        element.put("name", fLayerContainer[i].fName);
-        element.put("radius", "*" + std::to_string(fLayerContainer[i].fRadius) + "*");
-        element.put("frames_id", "*" + std::to_string(fLayerContainer[i].fSetup_id) + "*");
-        element.put("active", "true");
-        partial.push_back(std::make_pair("", element));
-      }
-      full.add_child("layers", partial);
-      
-      jsonFile.add_child(runNumberStr, full);
-      std::stringstream ss;
-      boost::property_tree::json_parser::write_json(ss, jsonFile);
-      std::string json = ss.str();
-      std::string placeholder = "\"*", placeholder2 = "*\"";
-      replace(json, placeholder);
-      replace(json, placeholder2);
-      
-      fileWithGeometry << json;
-      fileWithGeometry.close();
-    } else {
-      G4cout << "--- Creating new style of the geometry file ---" << G4endl;
-      boost::property_tree::ptree jsonFile, full, partial, element;
-      std::string runNumberStr = std::to_string(runNumber) + std::string(".");
+  G4cout << "--- Saving simulated geometry to " << fGeometryFileName << " ---" << G4endl;
+  auto runNumStr = to_string(fRunNumber+90);
+  pt::ptree jsonFile, full, partial, element;
 
-      partial.clear();
-      for (unsigned i=0; i<fLayerContainer.size(); i++) {
-        element.clear();
-        element.put("id", "*" + std::to_string(fLayerContainer[i].fId) + "*");
-        element.put("name", fLayerContainer[i].fName);
-        element.put("radius", "*" + std::to_string(fLayerContainer[i].fRadius) + "*");
-        element.put("setup_id", "*" + std::to_string(fLayerContainer[i].fSetup_id) + "*");
-        partial.push_back(std::make_pair("", element));
-      }
-      full.add_child("layer", partial);
+  if (fGeometryFileType == "barrel") {
+    G4cout << "--- Creating geometry file in Framework Big Barrel Format ---" << G4endl;
 
-      partial.clear();
-      for (unsigned i=0; i<fScinContainer.size(); i++) {
-        element.clear();
-        element.put("id", "*" + std::to_string(fScinContainer[i].fId) + "*");
-        element.put("slot_id", "*" + std::to_string(fScinContainer[i].fSlot_id) + "*");
-        std::stringstream stream, stream2, stream3;
-        stream << std::fixed << std::setprecision(0) << fScinContainer[i].fHeight;
-        element.put("height", "*" + stream.str() + "*");
-        stream2 << std::fixed << std::setprecision(0) << fScinContainer[i].fWidth;
-        element.put("width", "*" + stream2.str() + "*");
-        stream3 << std::fixed << std::setprecision(0) << fScinContainer[i].fLength;
-        element.put("length", "*" + stream3.str() + "*");
-        element.put("xcenter", "*" + std::to_string(fScinContainer[i].fX_center) + "*");
-        element.put("ycenter", "*" + std::to_string(fScinContainer[i].fY_center) + "*");
-        element.put("zcenter", "*" + std::to_string(fScinContainer[i].fZ_center) + "*");
-        partial.push_back(std::make_pair("", element));
-      }
-      full.add_child("scin", partial);
+    //! Adding Frame object - only one, always the same
+    element.put("id", 1);
+    element.put("creator_id", 1);
+    element.put("status", "OK");
+    element.put("description", "Setup generated with J-PET Geant4 software");
+    element.put("active", "true");
+    element.put("version", 1);
+    partial.push_back(make_pair("", element));
+    full.add_child("frames", partial);
 
-      partial.clear();
-      for (unsigned i=0; i<fSlotContainer.size(); i++) {
-        element.clear();
-        element.put("id", "*" + std::to_string(fSlotContainer[i].fId) + "*");
-        element.put("layer_id", "*" + std::to_string(fSlotContainer[i].fLayer_id) + "*");
-        std::stringstream stream;
-        stream << std::fixed << std::setprecision(3) << fSlotContainer[i].fTheta;
-        element.put("theta", "*" + stream.str() + "*");
-        element.put("type", fSlotContainer[i].fType);
-        partial.push_back(std::make_pair("", element));
-      }
-      full.add_child("slot", partial);
-      
-      jsonFile.add_child(runNumberStr, full);
-      std::stringstream ss;
-      boost::property_tree::json_parser::write_json(ss, jsonFile);
-      std::string json = ss.str();
-      std::string placeholder = "\"*", placeholder2 = "*\"";
-      replace(json, placeholder);
-      replace(json, placeholder2);
-      
-      fileWithGeometry << json;
-      fileWithGeometry.close();
+    //! Adding scintillators from collection of Scin objects added during construction
+    partial.clear();
+    for (unsigned i=0; i<fScinContainer.size(); i++) {
+      auto id = to_string(fScinContainer[i].fID);
+      auto bsID = to_string(fScinContainer[i].fSlotID);
+      auto height = to_string(fScinContainer[i].fHeight);
+      height = height.substr(0, height.find(".", 0)+3);
+      auto width = to_string(fScinContainer[i].fWidth);
+      width = width.substr(0, width.find(".", 0)+3);
+      auto length = to_string(fScinContainer[i].fLength);
+      length = length.substr(0, length.find(".", 0)+3);
+
+      element.clear();
+      element.put("id", id);
+      element.put("barrelSlots_id", bsID);
+      element.put("height", height);
+      element.put("width", width);
+      element.put("length", length);
+      element.put("attenuation_length", "0");
+      partial.push_back(make_pair("", element));
     }
-  }
-  else {
-    G4Exception("DetectorConstruction", "DC03",
-      JustWarning, "Failed to open a file to save geometry");
+    full.add_child("scintillators", partial);
+
+    //! Adding slots
+    partial.clear();
+    for (unsigned i=0; i<fSlotContainer.size(); i++) {
+      auto id = to_string(fSlotContainer[i].fID);
+      auto layerID = to_string(fSlotContainer[i].fLayerID);
+      auto theta = to_string(fSlotContainer[i].fTheta);
+      theta = theta.substr(0, theta.find(".", 0)+3);
+
+      element.clear();
+      element.put("id", id);
+      element.put("frame_id", "1");
+      element.put("name", "1");
+      element.put("layers_id", layerID);
+      element.put("theta1", theta);
+      element.put("active", "true");
+
+      partial.push_back(make_pair("", element));
+    }
+    full.add_child("barrelSlots", partial);
+
+    //! Adding layers
+    partial.clear();
+    for (unsigned i=0; i<fLayerContainer.size(); i++) {
+      auto id = to_string(fLayerContainer[i].fID);
+      auto name = fLayerContainer[i].fName;
+      auto radius = to_string(fLayerContainer[i].fRadius);
+      radius = radius.substr(0, radius.find(".", 0)+3);
+      auto frameID = to_string(fLayerContainer[i].fSetupID);
+
+      element.clear();
+      element.put("id", id);
+      element.put("name", name);
+      element.put("radius", radius);
+      element.put("frames_id", frameID);
+      element.put("active", "true");
+
+      partial.push_back(make_pair("", element));
+    }
+    full.add_child("layers", partial);
+
+    jsonFile.add_child(runNumStr, full);
+    pt::write_json(fGeometryFileName, jsonFile);
+
+  } else if (fGeometryFileType == "modular") {
+
+    G4cout << "--- Creating geometry file in Framework Modular Format ---" << G4endl;
+
+    //! Adding Setup object - only one, always the same
+    element.put("id", 1);
+    element.put("description", "Setup generated with J-PET Geant4 software");
+    partial.push_back(make_pair("", element));
+    full.add_child("setup", partial);
+
+    //! Adding Layers
+    partial.clear();
+    for (unsigned i=0; i<fLayerContainer.size(); i++) {
+      auto id = to_string(fLayerContainer[i].fID);
+      auto name = fLayerContainer[i].fName;
+      auto radius = to_string(fLayerContainer[i].fRadius);
+      radius = radius.substr(0, radius.find(".", 0)+3);
+      auto setupID = to_string(fLayerContainer[i].fSetupID);
+
+      element.clear();
+      element.put("id", id);
+      element.put("name", name);
+      element.put("radius", radius);
+      element.put("setup_id", setupID);
+      partial.push_back(make_pair("", element));
+    }
+    full.add_child("layer", partial);
+
+    //! Adding scintillators
+    partial.clear();
+    for (unsigned i=0; i<fScinContainer.size(); i++) {
+      auto id = to_string(fScinContainer[i].fID);
+      auto slotID = to_string(fScinContainer[i].fSlotID);
+      auto height = to_string(fScinContainer[i].fHeight);
+      height = height.substr(0, height.find(".", 0)+3);
+      auto width = to_string(fScinContainer[i].fWidth);
+      width = width.substr(0, width.find(".", 0)+3);
+      auto length = to_string(fScinContainer[i].fLength);
+      length = length.substr(0, length.find(".", 0)+3);
+      auto x_center = to_string(fScinContainer[i].fX_center);
+      x_center = x_center.substr(0, x_center.find(".", 0)+3);
+      auto y_center = to_string(fScinContainer[i].fY_center);
+      y_center = y_center.substr(0, y_center.find(".", 0)+3);
+      auto z_center = to_string(fScinContainer[i].fZ_center);
+      z_center = z_center.substr(0, z_center.find(".", 0)+3);
+
+      element.clear();
+      element.put("id", id);
+      element.put("slot_id", slotID);
+      element.put("height", height);
+      element.put("width", width);
+      element.put("length", length);
+      element.put("xcenter", x_center);
+      element.put("ycenter", y_center);
+      element.put("zcenter", z_center);
+      partial.push_back(make_pair("", element));
+    }
+    full.add_child("scin", partial);
+
+    //! Adding slots
+    partial.clear();
+    for (unsigned i=0; i<fSlotContainer.size(); i++) {
+      auto id = to_string(fSlotContainer[i].fID);
+      auto layerID = to_string(fSlotContainer[i].fLayerID);
+      auto theta = to_string(fSlotContainer[i].fTheta);
+      theta = theta.substr(0, theta.find(".", 0)+3);
+      auto type = fSlotContainer[i].fType;
+
+      element.clear();
+      element.put("id", id);
+      element.put("layer_id", layerID);
+      element.put("theta", theta);
+      element.put("type", type);
+      partial.push_back(make_pair("", element));
+    }
+    full.add_child("slot", partial);
+
+    jsonFile.add_child(runNumStr, full);
+    pt::write_json(fGeometryFileName, jsonFile);
+
+  } else {
+    G4Exception("DetectorConstruction", "DC03", JustWarning, "Unrecognized geometry file type, accepted formats: barrel, modular.");
   }
 }
 
-void replace(std::string& json, const std::string& placeholder) 
+void replace(std::string& json, const std::string& placeholder)
 {
     boost::replace_all<std::string>(json, placeholder, "");
 }

--- a/Core/DetectorConstruction.cpp
+++ b/Core/DetectorConstruction.cpp
@@ -1051,8 +1051,3 @@ void DetectorConstruction::CreateGeometryFile()
     G4Exception("DetectorConstruction", "DC03", JustWarning, "Unrecognized geometry file type, accepted formats: barrel, modular.");
   }
 }
-
-void replace(std::string& json, const std::string& placeholder)
-{
-    boost::replace_all<std::string>(json, placeholder, "");
-}

--- a/Core/DetectorConstruction.h
+++ b/Core/DetectorConstruction.h
@@ -84,10 +84,13 @@ public:
       fGeoKind = GeometryKind::Unknown;
     }
   }
+
+  //! Writing out detector setup in json format
   void CreateGeometryFileFlag(G4bool tf) { fCreateGeometryFile = tf; };
-  void SetOldStyleOfGeometryFile(G4bool tf) { fCreateOldGeometryFileStyle = tf; };
+  void SetGeometryFileName(G4String fileName) { fGeometryFileName = fileName; };
+  void SetGeometryFileType(G4String type) { fGeometryFileType = type; };
   void CreateGeometryFile();
-  
+
   G4int GetRunNumber() const { return fRunNumber; };
 
 private:
@@ -129,10 +132,10 @@ private:
   G4bool fLoadWrapping;
   //! Flag for loading modular (4th) layer
   G4bool fLoadModularLayer;
-  //! Flag for creating file with geometry
-  G4bool fCreateGeometryFile;
-  //! Flag for choosing old style of geometry file
-  G4bool fCreateOldGeometryFileStyle = false;
+  //! For creating file with geometry, by default not created, if yes, in big barrel format
+  G4bool fCreateGeometryFile = false;
+  G4String fGeometryFileName = "mc_geant_setup.json";
+  G4String fGeometryFileType = "barrel";
 
   G4Box* fWorldSolid = nullptr;
   G4LogicalVolume* fWorldLogical = nullptr;
@@ -155,43 +158,51 @@ private:
   GeometryKind fGeoKind = GeometryKind::Unknown;
   //! Maximum ID of the scintillators
   G4int maxScinID = 512;
-  
+
   std::vector<Layer> fLayerContainer;
   std::vector<Scin> fScinContainer;
   std::vector<Slot> fSlotContainer;
   G4int fLayerNumber = 0;
 };
 
+struct Frame {
+  int fID;
+  int fCreatorID;
+  int fVersion;
+  std::string fStatus;
+  std::string fDescription;
+  bool fActive;
+};
+
 struct Layer {
-  int fId;
+  int fID;
   std::string fName;
   double fRadius;
-  int fSetup_id;
-  Layer(int id, const std::string& name, double radius, int setup_id) : fId(id), fName(name),
-                                                fRadius(radius), fSetup_id(setup_id) {}
+  int fSetupID;
+  Layer(int id, const std::string& name, double radius, int setupID) :
+    fID(id), fName(name), fRadius(radius), fSetupID(setupID) {}
+};
+
+struct Slot {
+  int fID;
+  int fLayerID;
+  double fTheta;
+  std::string fType;
+  Slot(int id, int layerID, double theta, const std::string& type) :
+    fID(id), fLayerID(layerID), fTheta(theta), fType(type) {}
 };
 
 struct Scin {
-  int fId;
-  int fSlot_id;
+  int fID;
+  int fSlotID;
   float fHeight;
   float fWidth;
   float fLength;
   double fX_center;
   double fY_center;
   double fZ_center;
-  Scin(int id, int slot_id, double height, double width, double length, double x_center, double y_center,
-        double z_center) : fId(id), fSlot_id(slot_id), fHeight(height), fWidth(width), fLength(length),
-                            fX_center(x_center), fY_center(y_center), fZ_center(z_center) {}
-};
-
-struct Slot {
-  int fId;
-  int fLayer_id;
-  double fTheta;
-  std::string fType;
-  Slot(int id, int layer_id, double theta, const std::string& type) : fId(id), fLayer_id(layer_id),
-                                                fTheta(theta), fType(type) {}
+  Scin(int id, int slotID, double height, double width, double length, double x_center, double y_center, double z_center) :
+    fID(id), fSlotID(slotID), fHeight(height), fWidth(width), fLength(length), fX_center(x_center), fY_center(y_center), fZ_center(z_center) {}
 };
 
 void replace(std::string& json, const std::string& placeholder);

--- a/Info/DetectorConstructionMessenger.cpp
+++ b/Info/DetectorConstructionMessenger.cpp
@@ -45,12 +45,12 @@ DetectorConstructionMessenger::DetectorConstructionMessenger(DetectorConstructio
   fScinHitMergingTime->SetGuidance("Define time range (ns) while merging hits in scintillators");
   fScinHitMergingTime->SetDefaultUnit("ns");
   fScinHitMergingTime->SetUnitCandidates("ns");
-  
-  fCreateGeometryFile = new G4UIcmdWithoutParameter("/jpetmc/detector/createGeometryFile", this);
-  fCreateGeometryFile->SetGuidance("Create a Json file for the simulated setup");
-  
-  fCreateOldGeometryFileStyle = new G4UIcmdWithoutParameter("/jpetmc/detector/createOldGeometryFileStyle", this);
-  fCreateOldGeometryFileStyle->SetGuidance("Json file will be created with old style");
+
+  fGeometryFileName = new G4UIcmdWithAString("/jpetmc/detector/geometryFileName", this);
+  fGeometryFileName->SetGuidance("Create a JSON file for the simulated setup with a given name.");
+
+  fCreateGeometryType = new G4UIcmdWithAString("/jpetmc/detector/createGeometryType", this);
+  fCreateGeometryType->SetGuidance("Set structure of output JSON file: barrel or modular.");
 }
 
 DetectorConstructionMessenger::~DetectorConstructionMessenger()
@@ -61,8 +61,8 @@ DetectorConstructionMessenger::~DetectorConstructionMessenger()
   delete fLoadOnlyScintillators;
   delete fLoadModularLayer;
   delete fScinHitMergingTime;
-  delete fCreateGeometryFile;
-  delete fCreateOldGeometryFileStyle;
+  delete fGeometryFileName;
+  delete fCreateGeometryType;
 }
 
 // cppcheck-suppress unusedFunction
@@ -89,9 +89,14 @@ void DetectorConstructionMessenger::SetNewValue(G4UIcommand* command, G4String n
   } else if (command == fScinHitMergingTime) {
     DetectorConstants::SetMergingTimeValueForScin(fScinHitMergingTime->GetNewDoubleValue(newValue));
     fDetector->UpdateGeometry();
-  } else if (command == fCreateGeometryFile) {
+  } else if (command == fGeometryFileName) {
     fDetector->CreateGeometryFileFlag(true);
-  } else if (command == fCreateOldGeometryFileStyle) {
-    fDetector->SetOldStyleOfGeometryFile(true);
+    if(!newValue.contains(".json")){
+      newValue.append(".json");
+    }
+    fDetector->SetGeometryFileName(newValue);
+  } else if (command == fCreateGeometryType) {
+    fDetector->CreateGeometryFileFlag(true);
+    fDetector->SetGeometryFileType(newValue);
   }
 }

--- a/Info/DetectorConstructionMessenger.h
+++ b/Info/DetectorConstructionMessenger.h
@@ -48,8 +48,8 @@ private:
   //! Null pointer assigned to the modular layer -
   G4UIcmdWithAString* fLoadModularLayer = nullptr;
   G4UIcmdWithADoubleAndUnit* fScinHitMergingTime = nullptr;
-  G4UIcmdWithoutParameter* fCreateGeometryFile = nullptr;
-  G4UIcmdWithoutParameter* fCreateOldGeometryFileStyle = nullptr;
+  G4UIcmdWithAString* fGeometryFileName = nullptr;
+  G4UIcmdWithAString* fCreateGeometryType = nullptr;
 };
 
 #endif /* !DETECTORCONSTRUCTIONMESSENGER_H */

--- a/docs/PARAMETERS.md
+++ b/docs/PARAMETERS.md
@@ -72,3 +72,9 @@ Following options can be added to macro files, that are read by Geat4. Example f
  `/jpetmc/source/isotope/setPosition`  
 * set number of gamma quanta to generate 1 / 2 / 3 by the isotope  
  `/jpetmc/source/isotope/setNGamma`  
+
+## Creating .json file with geometry setup for J-PET Framework. If one of these two option will be put into macro, the output file will be created.
+* select a type of output file strucure - Big Barrel or Modular format (default "barrel")
+ `jpetmc/detector/createGeometryType`
+* name an output file (default name "mc_geant_setup.json")  
+ `/jpetmc/detector/geometryFileName`  

--- a/scripts/modSmCh.mac
+++ b/scripts/modSmCh.mac
@@ -13,11 +13,8 @@
 /jpetmc/detector/loadOnlyScintillators
 
 # Creating geometry file for analysis of the Framework
-# Created in the same file as executable file with name newGeometry.json
-/jpetmc/detector/createGeometryFile
-
-# Option for old style of the json file
-#/jpetmc/detector/createOldGeometryFileStyle
+/jpetmc/detector/createGeometryType barrel
+/jpetmc/detector/geometryFileName modular_mc_setup.json
 
 /run/initialize
 


### PR DESCRIPTION
After some testing, it turned out that topmost structure of Frame/Setup is needed, adding it to function that prepares boost::property_tree. 

- some parts of code were simplified
- added option to detector messenger to provide json file name 
- type of geometry printout is determined by string option "barrel"/"modular", description added to parameters readme
- corrected a small detail in json construction:

it was: { "95" : [ { ... }  ] }
should be: { "95" : { ... } }
(without inner "[ ]" brackets, which caused ParamManger to be unable to read the geomety into ParamBank)