### PR TITLE
Static linking

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -100,7 +100,7 @@ endif()
 ## Include GEANT4 WITH VIS DRIVERS
 ## remember to compile geant4 with following flags
 ## -DGEANT4_USE_QT=ON -DGEANT4_INSTALL_DATA=ON -DGEANT4_USE_OPENGL_X11=ON -DGEANT4_USE_GDML=ON
-find_package(Geant4 REQUIRED ui_all vis_all)
+find_package(Geant4 REQUIRED static ui_all vis_all)
 include(${Geant4_USE_FILE})
 
 ################################################################################
@@ -181,11 +181,15 @@ add_executable(jpet_mc JPetMC.cpp ${SOURCES})
 target_compile_options(jpet_mc PRIVATE -Wno-shadow)
 
 target_link_libraries(
-  jpet_mc
-  ${Geant4_LIBRARIES}
+  jpet_mc 
   ${ROOT_LIBRARIES}
   JPetMCClassesDict
-)
+  )
+
+target_link_libraries(
+  jpet_mc
+  ${Geant4_LIBRARIES}
+  )
 
 ## Copy script files to bin directory
 foreach(file_i ${SCRIPT_FILES})

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -193,13 +193,6 @@ target_link_libraries(
   JPetMCClassesDict
   )
 
-message(WARNING ${Geant4_LIBRARIES})
-
-target_link_libraries(
-  jpet_mc
-
-  )
-
 ## Copy script files to bin directory
 foreach(file_i ${SCRIPT_FILES})
   configure_file(

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -103,7 +103,7 @@ endif()
 set(GEANT4_LINK_OPTIONS "")
 if(LINK_STATIC_GEANT4)
   set(GEANT4_LINK_OPTIONS static)
-  message(INFO "Linking statically to Geant4 libraries.")
+  message(STATUS "Linking statically to Geant4 libraries.")
 endif()
 
 find_package(Geant4 REQUIRED ${GEANT4_LINK_OPTIONS} ui_all vis_all)

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -100,7 +100,13 @@ endif()
 ## Include GEANT4 WITH VIS DRIVERS
 ## remember to compile geant4 with following flags
 ## -DGEANT4_USE_QT=ON -DGEANT4_INSTALL_DATA=ON -DGEANT4_USE_OPENGL_X11=ON -DGEANT4_USE_GDML=ON
-find_package(Geant4 REQUIRED static ui_all vis_all)
+set(GEANT4_LINK_OPTIONS "")
+if(LINK_STATIC_GEANT4)
+  set(GEANT4_LINK_OPTIONS static)
+  message(INFO "Linking statically to Geant4 libraries.")
+endif()
+
+find_package(Geant4 REQUIRED ${GEANT4_LINK_OPTIONS} ui_all vis_all)
 include(${Geant4_USE_FILE})
 
 ################################################################################
@@ -183,12 +189,15 @@ target_compile_options(jpet_mc PRIVATE -Wno-shadow)
 target_link_libraries(
   jpet_mc 
   ${ROOT_LIBRARIES}
+  ${Geant4_LIBRARIES}
   JPetMCClassesDict
   )
 
+message(WARNING ${Geant4_LIBRARIES})
+
 target_link_libraries(
   jpet_mc
-  ${Geant4_LIBRARIES}
+
   )
 
 ## Copy script files to bin directory

--- a/Core/PrimaryGenerator.cpp
+++ b/Core/PrimaryGenerator.cpp
@@ -249,7 +249,7 @@ void PrimaryGenerator::GenerateEvtSmallChamber(
   //Not all Na decays lead to the emission of prompt photon
   if (decayRandom > MaterialParameters::fSodiumChanceNoPrompt) {
     //! Add prompt gamma from sodium
-    G4ThreeVector promptVtxPosition = VertexUniformInCylinder(0.2 * cm, 0.2 * cm) + chamberCenter;
+    G4ThreeVector promptVtxPosition = GenerateVertexUniformInCylinder(0.2 * cm, 0.2 * cm) + chamberCenter;
     event->AddPrimaryVertex(GeneratePromptGammaVertex(
         promptVtxPosition, 0.0f, MaterialParameters::fSodiumGammaTau,
         MaterialParameters::fSodiumGammaEnergy
@@ -368,7 +368,7 @@ void PrimaryGenerator::GenerateEvtLargeChamber(G4Event* event)
   //Not all Na decays lead to the emission of prompt photon
   if (decayRandom > MaterialParameters::fSodiumChanceNoPrompt) {
     //! Add prompt gamma from sodium
-    G4ThreeVector promptVtxPosition = VertexUniformInCylinder(0.2 * cm, 0.2 * cm) + chamberCenter;
+    G4ThreeVector promptVtxPosition = GenerateVertexUniformInCylinder(0.2 * cm, 0.2 * cm) + chamberCenter;
     event->AddPrimaryVertex(GeneratePromptGammaVertex(
         promptVtxPosition, 0.0f, MaterialParameters::fSodiumGammaTau,
         MaterialParameters::fSodiumGammaEnergy

--- a/docs/install.md
+++ b/docs/install.md
@@ -22,3 +22,24 @@ output file: (in build folder)
 `cmake .. && make doc`  
 - open the `doc/html/index.html` in your favorite web browser  
 
+# Advanced installation options
+
+## Statically linking to Geant4 libraries
+Using a statically-linked binary can speed up the execution of J-PET MC simulations by about 10%.
+
+In order to use static Geant4 linkage:
+
+1. Build Geant4 static libraries alongside with the (default) shared
+libraries by passing the following option to CMake in  addition to other flags:
+    ```
+    -DBUILD_STATIC_LIBS=ON
+    ```
+
+    As a result, in the installation directory of Geant4, in the `lib` sudbirectory
+    files with `*.a` extension should be present besides `*.so` files.
+
+2. When running CMake for J-PET-Geant4, pass in the following additional option:
+
+    ```
+    -DLINK_STATIC_GEANT4=ON
+    ```

--- a/jenkins/Jenkinsfile
+++ b/jenkins/Jenkinsfile
@@ -19,7 +19,7 @@ pipeline {
 		steps {
 		    echo 'Testing..'
 		    sh label: 'mkdir', script: 'mkdir -p CPPCheckRaport'
-		    sh label: 'cppcheck', script: 'cppcheck --inline-suppr --enable=all --inconclusive --xml --suppress="*:${WORKSPACE}/build/*.*" --suppress="*:${WORKSPACE}/CADMesh/*.*" --xml-version=2 ${WORKSPACE} 2> CPPCheckRaport/cppcheck.xml'
+		    sh label: 'cppcheck', script: 'cppcheck --inline-suppr --enable=all --inconclusive --xml -i ="${WORKSPACE}/build/" -i "${WORKSPACE}/CADMesh/" --xml-version=2 ${WORKSPACE} 2> CPPCheckRaport/cppcheck.xml'
 		}
 	    }
 	    stage('Deploy') {


### PR DESCRIPTION
Note: Please consider this PR after #64 

This PR introduces an option in CMake configuration to build the simulation binary statically linked to Geant4 libraries.
Tests have shown about 10% speedup of simulations in case of such static linking.

New CMake option introduced:
```
-DLINK_STATIC_GEANT4=ON
``` 
(OFF by default, resulting in dynamic linkage to Geant4)

Description of this flag and how to build static Geant4 libs was added to `docs/install.md`. 
