### PR TITLE
Correcting Saving 2G/3G events / Implementing saving fixed multiplici…

### DIFF
--- a/Actions/EventAction.cpp
+++ b/Actions/EventAction.cpp
@@ -26,10 +26,10 @@
 #include <G4Event.hh>
 #include "G4RunManager.hh"
 
-EventAction::EventAction() : is2gRec(false), is3gRec(false), fEventID(0)
+EventAction::EventAction() : is2gRec(false), is3gRec(false), isEnoughSize(false), fEventID(0)
 {}
 
-EventAction::EventAction(HistoManager* histo) : G4UserEventAction(), fHistoManager(histo), fScinCollID(-1), is2gRec(false), is3gRec(false), fEventID(0)
+EventAction::EventAction(HistoManager* histo) : G4UserEventAction(), fHistoManager(histo), fScinCollID(-1), is2gRec(false), is3gRec(false), isEnoughSize(false), fEventID(0)
 {}
 
 EventAction::~EventAction() {}
@@ -199,7 +199,6 @@ void EventAction::CheckIfEventHasEnoughSize(const G4Event* anEvent)
   int desiredSize = fEvtMessenger->GetMultiplicityToSaveEvent();
   G4double minEnergy = fEvtMessenger->GetEnergyRangeToSave().first;
   G4double maxEnergy = fEvtMessenger->GetEnergyRangeToSave().second;
-  int numberOfHitsWithEnoughEnergy = 0;
 
   G4HCofThisEvent * HCE = anEvent->GetHCofThisEvent();
   DetectorHitsCollection* DHC = 0;
@@ -207,6 +206,8 @@ void EventAction::CheckIfEventHasEnoughSize(const G4Event* anEvent)
     DHC = dynamic_cast<DetectorHitsCollection*>(HCE->GetHC(fScinCollID));
     int n_hit = DHC->entries();
     if (n_hit<desiredSize) return;
+
+    int numberOfHitsWithEnoughEnergy = 0;
     for (int i=0; i<n_hit; i++) {
        DetectorHit* dh =  dynamic_cast<DetectorHit*>(DHC->GetHit(i));
        if (((dh->GetEdep()/keV > minEnergy) || minEnergy < 0) && ((dh->GetEdep()/keV < maxEnergy) || maxEnergy < 0)) {

--- a/Actions/EventAction.h
+++ b/Actions/EventAction.h
@@ -40,8 +40,9 @@ public:
   virtual ~EventAction();
   virtual void BeginOfEventAction(const G4Event*);
   virtual void EndOfEventAction(const G4Event* anEvent);
-  bool Is2gRegistered();
-  bool Is3gRegistered();
+  bool Is2gRegistered() { return is2gRec; }
+  bool Is3gRegistered() { return is3gRec; }
+  bool IsEnoughSize() { return isEnoughSize; }
 
 private:
   HistoManager* fHistoManager = nullptr;
@@ -51,9 +52,11 @@ private:
 
   bool is2gRec;
   bool is3gRec;
+  bool isEnoughSize;
   int fEventID;
-  void CheckIf3gIsRegistered(const G4Event* anEvent);
   void CheckIf2gIsRegistered(const G4Event* anEvent);
+  void CheckIf3gIsRegistered(const G4Event* anEvent);
+  void CheckIfEventHasEnoughSize(const G4Event* anEvent);
 
 };
 

--- a/Actions/PrimaryGeneratorAction.cpp
+++ b/Actions/PrimaryGeneratorAction.cpp
@@ -85,7 +85,7 @@ void PrimaryGeneratorAction::GeneratePrimaries(G4Event* event)
   } else if (GetSourceTypeInfo() == ("nema-mixed")) {
     fPrimaryGenerator->GenerateNema(event, &fNemaGenerator);
   } else if (GetSourceTypeInfo() == ("cosmics")) {
-    fPrimaryGenerator->GenerateCosmicVertex(fIsotope, event, fHistoManager); 
+    fPrimaryGenerator->GenerateCosmicVertex(fIsotope, event, fHistoManager);
   } else {
     G4Exception(
       "PrimaryGeneratorAction", "PG05", FatalException,
@@ -105,6 +105,8 @@ void PrimaryGeneratorAction::SetSourceTypeInfo(G4String newSourceType)
       fGenerateSourceType = newSourceType;
       if (newSourceType == "nema") {
         GenerateDefaultNemaPositions();
+      } else if (newSourceType == "cosmics") {
+        fHistoManager->SetCosmicHistoCreation(true);
       }
     } else if (nRun > 0) {
       fGenerateSourceType = "run";

--- a/Core/HistoManager.cpp
+++ b/Core/HistoManager.cpp
@@ -247,7 +247,6 @@ void HistoManager::BookHistograms()
     "E_1 generated [keV]", "Entries"
   );
 
-
   createHistogramWithAxes(
     new TH2D(
       "gen_gamma_multiplicity_vs_lifetime",
@@ -268,29 +267,40 @@ void HistoManager::BookHistograms()
   );
   
   createHistogramWithAxes(
-    new TH1D("cosm_theta", "Cosmics: theta angle", 184, -M_PI/2 - 2.5, M_PI/2 + 1.5),
-    "theta [rad]", "number of entries"
-  );
-  createHistogramWithAxes(
-    new TH2D("cosm_vtx_xy", "Cosmics: generated vertex point XY",
-    204*(DetectorConstants::world_size[1]/m), -1.015*DetectorConstants::world_size[1], 1.025*DetectorConstants::world_size[1],
-    204*(DetectorConstants::world_size[0]/m), -1.015*DetectorConstants::world_size[0], 1.025*DetectorConstants::world_size[0]),
-    "Y position [cm]", "X position [cm]"
+    new TH2D(
+      "gen_event_multiplicity_vs_energy",
+      "Generated event multiplicity vs generated energies of the hits. Bin size: 1 x 100 ps",
+      20, -0.5, 19.5, 750, -1.0, 1499.0
+    ),
+    "Event Multiplicity", "Energy of the hit [keV]"
   );
 
-  createHistogramWithAxes(
-    new TH2D("cosm_vtx_xz", "Cosmics: generated vertex point XZ",
-    204*(DetectorConstants::world_size[2]/m), -1.015*DetectorConstants::world_size[2], 1.025*DetectorConstants::world_size[2],
-    204*(DetectorConstants::world_size[0]/m), -1.015*DetectorConstants::world_size[0], 1.025*DetectorConstants::world_size[0]),
-    "Z position [cm]", "X position [cm]"
-  );
+  if (fMakeCosmicHistos) {
+    createHistogramWithAxes(
+      new TH1D("cosm_theta", "Cosmics: theta angle", 184, -M_PI/2 - 2.5, M_PI/2 + 1.5),
+      "theta [rad]", "number of entries"
+    );
+    createHistogramWithAxes(
+      new TH2D("cosm_vtx_xy", "Cosmics: generated vertex point XY",
+      204*(DetectorConstants::world_size[1]/m), -1.015*DetectorConstants::world_size[1], 1.025*DetectorConstants::world_size[1],
+      204*(DetectorConstants::world_size[0]/m), -1.015*DetectorConstants::world_size[0], 1.025*DetectorConstants::world_size[0]),
+      "Y position [cm]", "X position [cm]"
+    );
 
-  createHistogramWithAxes(
-    new TH2D("cosm_vtx_yz", "Cosmics: generated vertex point YZ",
-    204*(DetectorConstants::world_size[1]/m), -1.015*DetectorConstants::world_size[1], 1.025*DetectorConstants::world_size[1],
-    204*(DetectorConstants::world_size[2]/m), -1.015*DetectorConstants::world_size[2], 1.025*DetectorConstants::world_size[2]),
-    "Y position [cm]", "Z position [cm]"
-  );
+    createHistogramWithAxes(
+      new TH2D("cosm_vtx_xz", "Cosmics: generated vertex point XZ",
+      204*(DetectorConstants::world_size[2]/m), -1.015*DetectorConstants::world_size[2], 1.025*DetectorConstants::world_size[2],
+      204*(DetectorConstants::world_size[0]/m), -1.015*DetectorConstants::world_size[0], 1.025*DetectorConstants::world_size[0]),
+      "Z position [cm]", "X position [cm]"
+    );
+
+    createHistogramWithAxes(
+      new TH2D("cosm_vtx_yz", "Cosmics: generated vertex point YZ",
+      204*(DetectorConstants::world_size[1]/m), -1.015*DetectorConstants::world_size[1], 1.025*DetectorConstants::world_size[1],
+      204*(DetectorConstants::world_size[2]/m), -1.015*DetectorConstants::world_size[2], 1.025*DetectorConstants::world_size[2]),
+      "Y position [cm]", "Z position [cm]"
+    );
+  }
 }
 
 void HistoManager::FillHistoGenInfo(const G4Event* anEvent)
@@ -318,10 +328,12 @@ void HistoManager::FillHistoGenInfo(const G4Event* anEvent)
 
 void HistoManager::FillCosmicInfo(G4double theta, G4ThreeVector init, G4ThreeVector orig)
 {
-  fillHistogram("cosm_theta", theta);
-  fillHistogram("cosm_vtx_xy", init.y(), doubleCheck(init.x()));
-  fillHistogram("cosm_vtx_xz", init.z(), doubleCheck(init.x()));
-  fillHistogram("cosm_vtx_yz", init.z(), doubleCheck(init.y()));
+  if (fMakeCosmicHistos) {
+    fillHistogram("cosm_theta", theta);
+    fillHistogram("cosm_vtx_xy", init.y(), doubleCheck(init.x()));
+    fillHistogram("cosm_vtx_xz", init.z(), doubleCheck(init.x()));
+    fillHistogram("cosm_vtx_yz", init.z(), doubleCheck(init.y()));
+  }
 }
 
 void HistoManager::AddGenInfoParticles(G4PrimaryParticle* particle)
@@ -446,6 +458,13 @@ void HistoManager::AddNewHit(DetectorHit* hit)
       double signCheck = (hit->GetPosition().getY() >= 0 ? 1 : -1);
       fillHistogram("gen_multiplicity_vs_theta", signCheck*M_PI/2);
     }
+  }
+}
+
+void HistoManager::AddEventInfo(DetectorHit* hit, int eventSize)
+{
+  if (GetMakeControlHisto()) {
+    fillHistogram("gen_event_multiplicity_vs_energy", eventSize, doubleCheck(hit->GetEdep()/keV));
   }
 }
 

--- a/Core/HistoManager.cpp
+++ b/Core/HistoManager.cpp
@@ -300,6 +300,13 @@ void HistoManager::BookHistograms()
       204*(DetectorConstants::world_size[2]/m), -1.015*DetectorConstants::world_size[2], 1.025*DetectorConstants::world_size[2]),
       "Y position [cm]", "Z position [cm]"
     );
+
+    createHistogramWithAxes(
+      new TH2D("cosm_genPoint_yz", "Cosmics: generated 'in the roof' point YZ",
+      204*(DetectorConstants::world_size[1]/m), -1.015*DetectorConstants::world_size[1], 1.025*DetectorConstants::world_size[1],
+      204*(DetectorConstants::world_size[2]/m), -1.015*DetectorConstants::world_size[2], 1.025*DetectorConstants::world_size[2]),
+      "Y position [cm]", "Z position [cm]"
+    );
   }
 }
 
@@ -333,6 +340,7 @@ void HistoManager::FillCosmicInfo(G4double theta, G4ThreeVector init, G4ThreeVec
     fillHistogram("cosm_vtx_xy", init.y(), doubleCheck(init.x()));
     fillHistogram("cosm_vtx_xz", init.z(), doubleCheck(init.x()));
     fillHistogram("cosm_vtx_yz", init.z(), doubleCheck(init.y()));
+    fillHistogram("cosm_genPoint_yz", orig.z(), doubleCheck(orig.y()));
   }
 }
 

--- a/Core/HistoManager.h
+++ b/Core/HistoManager.h
@@ -66,15 +66,18 @@ public:
   void Save(); //! call once; save all trees and histograms
   void SaveEvtPack();
   void Clear() { fEventPack->Clear(); };
+  void DontSaveEvent() { fEmptyEvent = true; SaveEvtPack(); };
   void AddGenInfo(VtxInformation* info);
   void AddGenInfoParticles(G4PrimaryParticle* particle);
   void AddNewHit(DetectorHit*);
+  void AddEventInfo(DetectorHit* hit, int eventSize);
   void AddNodeToDecayTree(int nodeID, int trackID);
   void SetParentIDofPhoton(int x) { fParentIDofPhoton = x; };
   int GetParentIDofPhoton() const { return fParentIDofPhoton; };
   void SetEventNumber(int x) { fEventPack->SetEventNumber(x); };
   int GetEventNumber() { return fEventPack->GetEventNumber(); };
   void SetHistogramCreation(bool tf) { fMakeControlHisto = tf; };
+  void SetCosmicHistoCreation(bool tf) { fMakeCosmicHistos = tf; };
   bool GetMakeControlHisto() const { return fMakeControlHisto; };
   void SetDecayChannel(DecayChannel decayChannel) { fDecayChannel = decayChannel; };
   void FillHistoGenInfo(const G4Event* anEvent);
@@ -106,6 +109,7 @@ private:
   DecayChannel fDecayChannel;
   bool fBookStatus = false;
   bool fMakeControlHisto = false;
+  bool fMakeCosmicHistos = false;
   TFile* fRootFile = nullptr;
   TTree* fTree = nullptr;
   TBranch* fBranchTrk = nullptr;

--- a/Info/EventMessenger.cpp
+++ b/Info/EventMessenger.cpp
@@ -83,8 +83,11 @@ EventMessenger::EventMessenger()
   fCMDAppliedRangeCut->SetDefaultValue(1 * mm);
   fCMDAppliedRangeCut->SetUnitCandidates("mm");
 
-  fCMDSaveEnoughSizedEvent = new G4UIcmdWithAnInteger("/jpetmc/event/saveEventWithSize", this);
-  fCMDSaveEnoughSizedEvent->SetGuidance("Set the size of the event you want to save");
+  fCMDSaveMinSizedEvent = new G4UIcmdWithAnInteger("/jpetmc/event/saveEventWithMinSize", this);
+  fCMDSaveMinSizedEvent->SetGuidance("Set the minimal size of the event you want to save");
+  
+  fCMDSaveMaxSizedEvent = new G4UIcmdWithAnInteger("/jpetmc/event/saveEventWithMaxSize", this);
+  fCMDSaveMaxSizedEvent->SetGuidance("Set the maximal size of the event you want to save");
 
   fSetEnergyRangeToSave = new G4UIcmdWith3VectorAndUnit("/jpetmc/event/setEnergyRange", this);
   fSetEnergyRangeToSave->SetGuidance("Set energy range for checking the event size (first minEnergy then maxEnergy then control option to connect with saveEventWithSize) - works with saveEventWithSize!!");
@@ -113,7 +116,8 @@ EventMessenger::~EventMessenger()
   delete fCMDExcludedMulti;
   delete fCMDAppliedEnergyCut;
   delete fCMDAppliedRangeCut;
-  delete fCMDSaveEnoughSizedEvent;
+  delete fCMDSaveMinSizedEvent;
+  delete fCMDSaveMaxSizedEvent;
   delete fSetEnergyRangeToSave;
   delete fCreateDecayTree;
 }
@@ -152,8 +156,10 @@ void EventMessenger::SetNewValue(G4UIcommand* command, G4String newValue)
     fSave2g = fCMDSave2g->GetNewBoolValue(newValue);
   } else if (command == fCMDSave3g) {
     fSave3g = fCMDSave3g->GetNewBoolValue(newValue);
-  } else if (command == fCMDSaveEnoughSizedEvent) {
-    fEventDesiredSize = fCMDSaveEnoughSizedEvent->GetNewIntValue(newValue);
+  } else if (command == fCMDSaveMinSizedEvent) {
+    fEventDesiredSize.first = fCMDSaveMinSizedEvent->GetNewIntValue(newValue);
+  } else if (command == fCMDSaveMaxSizedEvent) {
+    fEventDesiredSize.second = fCMDSaveMaxSizedEvent->GetNewIntValue(newValue);
   } else if (command == fSetEnergyRangeToSave) {
     G4String paramString = newValue;
     std::istringstream is(paramString);
@@ -163,8 +169,13 @@ void EventMessenger::SetNewValue(G4UIcommand* command, G4String newValue)
     is >> minEnergy >> maxEnergy >> strictMultCheck;
     fEnergyRangeToSave = std::make_pair(minEnergy, maxEnergy);
     fMultEnergyCheck = strictMultCheck;
-    if (fEventDesiredSize < 1)
-      fEventDesiredSize = 1000;
+    if (fEventDesiredSize.first < 1) {
+      G4Exception(
+        "EventMessenger", "EM01",
+        JustWarning, "Setting minimal event multiplicity to save to 1"
+      );
+      fEventDesiredSize.first = 1;
+    }
   } else if (command == fCreateDecayTree) {
     fCreateDecayTreeFlag = fCreateDecayTree->GetNewBoolValue(newValue);
   }

--- a/Info/EventMessenger.cpp
+++ b/Info/EventMessenger.cpp
@@ -83,6 +83,16 @@ EventMessenger::EventMessenger()
   fCMDAppliedRangeCut->SetDefaultValue(1 * mm);
   fCMDAppliedRangeCut->SetUnitCandidates("mm");
 
+  fCMDSaveEnoughSizedEvent = new G4UIcmdWithAnInteger("/jpetmc/event/saveEventWithSize", this);
+  fCMDSaveEnoughSizedEvent->SetGuidance("Set the size of the event you want to save");
+
+  fSetEnergyRangeToSave = new G4UIcmdWith3VectorAndUnit("/jpetmc/event/setEnergyRange", this);
+  fSetEnergyRangeToSave->SetGuidance("Set energy range for checking the event size (first minEnergy then maxEnergy) - works with saveEventWithSize!!");
+  fSetEnergyRangeToSave->SetDefaultValue(G4ThreeVector(-1*keV, -1*keV, 0));
+  fSetEnergyRangeToSave->SetDefaultUnit("keV");
+  fSetEnergyRangeToSave->SetUnitCandidates("keV");
+  fSetEnergyRangeToSave->SetParameterName("MinEnergy", "MaxEnergy", "none", false);
+
   fCreateDecayTree = new G4UIcmdWithABool("/jpetmc/output/CreateDecayTree", this);
   fCreateDecayTree->SetGuidance("Creates decay trees for each event.");
 }
@@ -96,13 +106,15 @@ EventMessenger::~EventMessenger()
   delete fSetSeed;
   delete fSaveSeed;
   delete fCMDKillEventsEscapingWorld;
+  delete fCMDSave2g;
+  delete fCMDSave3g;
   delete fCMDMinRegMulti;
   delete fCMDMaxRegMulti;
   delete fCMDExcludedMulti;
   delete fCMDAppliedEnergyCut;
   delete fCMDAppliedRangeCut;
-  delete fCMDSave2g;
-  delete fCMDSave3g;
+  delete fCMDSaveEnoughSizedEvent;
+  delete fSetEnergyRangeToSave;
   delete fCreateDecayTree;
 }
 
@@ -136,11 +148,22 @@ void EventMessenger::SetNewValue(G4UIcommand* command, G4String newValue)
   } else if (command == fCMDAppliedRangeCut) {
     fRangeCut = fCMDAppliedRangeCut->GetNewDoubleValue(newValue);
     fUseRangeCut = true;
-  } else if (command == fCreateDecayTree) {
-    fCreateDecayTreeFlag = fCreateDecayTree->GetNewBoolValue(newValue);
   } else if (command == fCMDSave2g) {
     fSave2g = fCMDSave2g->GetNewBoolValue(newValue);
   } else if (command == fCMDSave3g) {
     fSave3g = fCMDSave3g->GetNewBoolValue(newValue);
+  } else if (command == fCMDSaveEnoughSizedEvent) {
+    fEventDesiredSize = fCMDSaveEnoughSizedEvent->GetNewIntValue(newValue);
+  } else if (command == fSetEnergyRangeToSave) {
+    G4String paramString = newValue;
+    std::istringstream is(paramString);
+    G4double minEnergy;
+    G4double maxEnergy;
+    bool strictMultCheck;
+    is >> minEnergy >> maxEnergy >> strictMultCheck;
+    fEnergyRangeToSave = std::make_pair(minEnergy, maxEnergy);
+    fMultEnergyCheck = strictMultCheck;
+  } else if (command == fCreateDecayTree) {
+    fCreateDecayTreeFlag = fCreateDecayTree->GetNewBoolValue(newValue);
   }
 }

--- a/Info/EventMessenger.cpp
+++ b/Info/EventMessenger.cpp
@@ -87,7 +87,7 @@ EventMessenger::EventMessenger()
   fCMDSaveEnoughSizedEvent->SetGuidance("Set the size of the event you want to save");
 
   fSetEnergyRangeToSave = new G4UIcmdWith3VectorAndUnit("/jpetmc/event/setEnergyRange", this);
-  fSetEnergyRangeToSave->SetGuidance("Set energy range for checking the event size (first minEnergy then maxEnergy) - works with saveEventWithSize!!");
+  fSetEnergyRangeToSave->SetGuidance("Set energy range for checking the event size (first minEnergy then maxEnergy then control option to connect with saveEventWithSize) - works with saveEventWithSize!!");
   fSetEnergyRangeToSave->SetDefaultValue(G4ThreeVector(-1*keV, -1*keV, 0));
   fSetEnergyRangeToSave->SetDefaultUnit("keV");
   fSetEnergyRangeToSave->SetUnitCandidates("keV");
@@ -163,6 +163,8 @@ void EventMessenger::SetNewValue(G4UIcommand* command, G4String newValue)
     is >> minEnergy >> maxEnergy >> strictMultCheck;
     fEnergyRangeToSave = std::make_pair(minEnergy, maxEnergy);
     fMultEnergyCheck = strictMultCheck;
+    if (fEventDesiredSize < 1)
+      fEventDesiredSize = 1000;
   } else if (command == fCreateDecayTree) {
     fCreateDecayTreeFlag = fCreateDecayTree->GetNewBoolValue(newValue);
   }

--- a/Info/EventMessenger.h
+++ b/Info/EventMessenger.h
@@ -51,6 +51,9 @@ public:
   bool SaveSeed() { return fSaveRandomSeed; }
   bool Save2g() { return fSave2g; }
   bool Save3g() { return fSave3g; }
+  G4int GetMultiplicityToSaveEvent() { return fEventDesiredSize; }
+  std::pair<G4double, G4double> GetEnergyRangeToSave() { return fEnergyRangeToSave; }
+  bool GetMultiplicityToSaveEventWithEnergy() { return fMultEnergyCheck; }
   bool GetCreateDecayTreeFlag() { return fCreateDecayTreeFlag; }
 
 private:
@@ -68,6 +71,7 @@ private:
   G4UIcmdWithAnInteger* fCMDMaxRegMulti = nullptr;
   G4UIcmdWithAnInteger* fCMDExcludedMulti = nullptr;
   G4UIcmdWithAnInteger* fSetSeed = nullptr;
+  G4UIcmdWithAnInteger* fCMDSaveEnoughSizedEvent = nullptr;
   G4UIcmdWithABool* fSaveSeed = nullptr;
   G4UIcmdWithADoubleAndUnit* fCMDAllowedMomentumTransfer = nullptr;
   G4UIcmdWithADoubleAndUnit* fCMDAppliedEnergyCut = nullptr;
@@ -75,6 +79,7 @@ private:
   G4UIcmdWithABool* fCMDSave2g = nullptr;
   G4UIcmdWithABool* fCMDSave3g = nullptr;
   G4UIcmdWithABool* fCreateDecayTree = nullptr;
+  G4UIcmdWith3VectorAndUnit* fSetEnergyRangeToSave = nullptr;
   
   bool fPrintStatistics = false;
   G4int fPrintPower = 10;
@@ -93,6 +98,9 @@ private:
   G4double fRangeCut  = 1 * mm;
   bool fSave2g = false;
   bool fSave3g = false;
+  G4int fEventDesiredSize = 0;
+  std::pair<G4double, G4double> fEnergyRangeToSave = {-1*keV, -1*keV};
+  bool fMultEnergyCheck = false;
   bool fCreateDecayTreeFlag = false;
 };
 

--- a/Info/EventMessenger.h
+++ b/Info/EventMessenger.h
@@ -51,7 +51,7 @@ public:
   bool SaveSeed() { return fSaveRandomSeed; }
   bool Save2g() { return fSave2g; }
   bool Save3g() { return fSave3g; }
-  G4int GetMultiplicityToSaveEvent() { return fEventDesiredSize; }
+  std::pair<G4int, G4int> GetMultiplicityToSaveEvent() { return fEventDesiredSize; }
   std::pair<G4double, G4double> GetEnergyRangeToSave() { return fEnergyRangeToSave; }
   bool GetMultiplicityToSaveEventWithEnergy() { return fMultEnergyCheck; }
   bool GetCreateDecayTreeFlag() { return fCreateDecayTreeFlag; }
@@ -71,7 +71,8 @@ private:
   G4UIcmdWithAnInteger* fCMDMaxRegMulti = nullptr;
   G4UIcmdWithAnInteger* fCMDExcludedMulti = nullptr;
   G4UIcmdWithAnInteger* fSetSeed = nullptr;
-  G4UIcmdWithAnInteger* fCMDSaveEnoughSizedEvent = nullptr;
+  G4UIcmdWithAnInteger* fCMDSaveMinSizedEvent = nullptr;
+  G4UIcmdWithAnInteger* fCMDSaveMaxSizedEvent = nullptr;
   G4UIcmdWithABool* fSaveSeed = nullptr;
   G4UIcmdWithADoubleAndUnit* fCMDAllowedMomentumTransfer = nullptr;
   G4UIcmdWithADoubleAndUnit* fCMDAppliedEnergyCut = nullptr;
@@ -98,7 +99,7 @@ private:
   G4double fRangeCut  = 1 * mm;
   bool fSave2g = false;
   bool fSave3g = false;
-  G4int fEventDesiredSize = 0;
+  std::pair<G4int, G4int> fEventDesiredSize = {0, 0};
   std::pair<G4double, G4double> fEnergyRangeToSave = {-1*keV, -1*keV};
   bool fMultEnergyCheck = false;
   bool fCreateDecayTreeFlag = false;

--- a/docs/PARAMETERS.md
+++ b/docs/PARAMETERS.md
@@ -62,8 +62,14 @@ Following options can be added to macro files, that are read by Geat4. Example f
  `/jpetmc/event/save2g`  
 * save event when 2g were registered (default false):  
  `/jpetmc/event/save3g`  
-  save event when 3g were registered (default false):  
+* save event when 3g were registered (default false):
   Options save2g/save3g  and saveEvtsDetAcc are separable !
+* save event with fixed number of hits to save (default 0 means all):
+ `/jpetmc/event/saveEventWithSize [int]`
+* save event with fixed number of hits to save and within the given energy window (default -1 keV energy means all energies):
+The third argument is an additional option: 0 -> save all events in which there was N hits within energy window
+1 -> save only events that have only fixed number of hits, which is in the energy window
+ `/jpetmc/event/setEnergyRange [min energy in keV - double] [max energy in keV - double] [bool]`
 * print how many events were generated:  
  `/jpetmc/event/printEvtStat`  
 * print out option during execution of the simulation - X in divisor (10^X) for number of printed events:  

--- a/docs/PARAMETERS.md
+++ b/docs/PARAMETERS.md
@@ -64,11 +64,13 @@ Following options can be added to macro files, that are read by Geat4. Example f
  `/jpetmc/event/save3g`  
 * save event when 3g were registered (default false):
   Options save2g/save3g  and saveEvtsDetAcc are separable !
-* save event with fixed number of hits to save (default 0 means all):
- `/jpetmc/event/saveEventWithSize [int]`
+* save event with fixed minimal number of hits to save (default 0 means all):
+ `/jpetmc/event/saveEventWithMinSize [int]`
+* save event with fixed minimal number of hits to save (default 0 means all):
+ `/jpetmc/event/saveEventWithMaxSize [int]`
 * save event with fixed number of hits to save and within the given energy window (default -1 keV energy means all energies):
 The third argument is an additional option: 0 -> save all events in which there was N hits within energy window
-1 -> save only events that have only fixed number of hits, which is in the energy window
+1 -> save only events that have only minimal fixed number of hits, which is in the energy window
  `/jpetmc/event/setEnergyRange [min energy in keV - double] [max energy in keV - double] [bool]`
 * print how many events were generated:  
  `/jpetmc/event/printEvtStat`  


### PR DESCRIPTION
…ty within energy window

There was a problem: when setting flag to save 2G or 3G events, still all of the events were saved. I fixed it so only the selected events are saved (2G, 3G), but it does works like that at the moment: Simulating N events with 2G flag on -> only some fraction of N that were 2G are saved, the rest is dropped. It must be discussed if it should be like simulating N 2G events, but then there is a conflict when setting a given decay mode, which in principal will work similar way

Two new things added:
- Flag for saving events only if there was explicit size of the hits in an event
- Options for setting that there should be explicit number of hits within the energy window given by the user in macro: one additional option to join fixed multiplicity and event size, so user will for example have only 5Hit events, where only 2 of them are in the energy window between 400 and 600 keV