### PR TITLE
fix:program correctly builds with boost on the cluster and new ubuntu versions

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -139,6 +139,9 @@ if(NOT TARGET Boost::filesystem)
         INTERFACE_LINK_LIBRARIES ${Boost_LIBRARIES})
 endif()
 
+include_directories(${Boost_INCLUDE_DIRS})
+add_definitions(${Boost_DEFINITIONS})
+link_directories(${Boost_LIBRARY_DIRS})
 ################################################################################
 ## Include ROOT
 find_package(ROOT REQUIRED)


### PR DESCRIPTION
For some reasons code compilations fails with error:

```
J-PET-geant4/Core/DetectorConstruction.cpp:32:10: fatal error: boost/algorithm/string.hpp: No such file or directory
 #include <boost/algorithm/string.hpp>
```

This error can be fixed with 3 extra lines in the cmake.