### PR TITLE
Rotate Modular detector by 7.5 degrees

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -121,24 +121,6 @@ include(${Geant4_USE_FILE})
 ## Include header-only CADMesh library
 include_directories(SYSTEM ${CMAKE_CURRENT_SOURCE_DIR}/CADMesh/)
 
-################################################################################
-## Include Boost
-#set(Boost_USE_STATIC_LIBS OFF)
-#set(Boost_USE_MULTITHREADED ON)
-#set(Boost_USE_STATIC_RUNTIME OFF)
-#find_package(Boost 1.50 REQUIRED
-#             COMPONENTS filesystem
-#                        program_options
-#                        regex
-#                        system
-#                        log_setup
-#                        log
-#                        date_time
-#                        thread
-#                        chrono
-#                        atomic
-#                        )
-
 #if(NOT TARGET Boost::filesystem)
 #    add_library(Boost::filesystem IMPORTED INTERFACE)
 #    set_property(TARGET Boost::filesystem PROPERTY

--- a/Core/DetectorConstruction.cpp
+++ b/Core/DetectorConstruction.cpp
@@ -394,10 +394,6 @@ void DetectorConstruction::ConstructScintillators()
       rot.rotateZ(phi + fi);
 
       G4ThreeVector loc = G4ThreeVector(DetectorConstants::radius[j] * (cos(phi + fi)), DetectorConstants::radius[j] * (sin(phi + fi)), 0.0);
-
-      std::cout << "scin id " << fMaxScinID << " x " << DetectorConstants::radius[j] * (cos(phi + fi)) << " y "
-                << DetectorConstants::radius[j] * (sin(phi + fi)) << " rotation " << (phi + fi) << std::endl;
-
       G4Transform3D transform(rot, loc);
       G4String name = "scin_" + G4UIcommand::ConvertToString(fMaxScinID);
 

--- a/Core/DetectorConstruction.cpp
+++ b/Core/DetectorConstruction.cpp
@@ -395,6 +395,9 @@ void DetectorConstruction::ConstructScintillators()
 
       G4ThreeVector loc = G4ThreeVector(DetectorConstants::radius[j] * (cos(phi + fi)), DetectorConstants::radius[j] * (sin(phi + fi)), 0.0);
 
+      std::cout << "scin id " << fMaxScinID << " x " << DetectorConstants::radius[j] * (cos(phi + fi)) << " y "
+                << DetectorConstants::radius[j] * (sin(phi + fi)) << " rotation " << (phi + fi) << std::endl;
+
       G4Transform3D transform(rot, loc);
       G4String name = "scin_" + G4UIcommand::ConvertToString(fMaxScinID);
 
@@ -515,7 +518,8 @@ void DetectorConstruction::ConstructLayers(std::vector<G4double>& radius_dynamic
   G4int moduleNumber = 0;
   for (int i = 0; i < numberofModules; i++)
   {
-    phi = (i * 2 * M_PI / numberofModules);
+    // Add 7.5 deg to make as the clinical version of the prototype
+    phi = (i * 2 * M_PI / numberofModules) + 7.5 * M_PI / 180.0;
     for (int j = -6; j < 7; j++)
     {
       phi1 = phi + j * angDisp_dynamic;


### PR DESCRIPTION
This change rotates the modular detector by 7.5 degrees to reflect the construction that was made for 2022 hospital studies, and it has been used since then. 

Also some clean up of the CMakeLists to exclude Boost lob dependency. 

![second_modular_setup](https://github.com/user-attachments/assets/0947c1c7-fe22-400f-8cea-1bc2c098968b)
![first_modular_setup](https://github.com/user-attachments/assets/059e1678-c407-4eda-8de0-f02cf5aab66a)
